### PR TITLE
Fix offset in get_malloc_mapinfo.

### DIFF
--- a/src/malloc.c
+++ b/src/malloc.c
@@ -36,7 +36,7 @@ struct mmap_record {
   UT_hash_handle hh_pointer;
 };
 
-// TODO(rshin): Don't have two hash tables.
+/* TODO(rshin): Don't have two hash tables. */
 struct mmap_record *records_by_fd = NULL;
 struct mmap_record *records_by_pointer = NULL;
 
@@ -66,14 +66,13 @@ int create_buffer(int64_t size) {
 }
 
 void *fake_mmap(size_t size) {
-  // Add sizeof(size_t) so that the returned pointer is deliberately not
-  // page-aligned. This ensures that the segments of memory returned by
-  // fake_mmap are never contiguous.
+  /* Add sizeof(size_t) so that the returned pointer is deliberately not
+   * page-aligned. This ensures that the segments of memory returned by
+   * fake_mmap are never contiguous. */
   size += sizeof(size_t);
 
   int fd = create_buffer(size);
-  void *pointer = mmap(NULL, size, PROT_READ | PROT_WRITE,
-                       MAP_SHARED, fd, 0);
+  void *pointer = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (pointer == MAP_FAILED) {
     return pointer;
   }
@@ -85,7 +84,7 @@ void *fake_mmap(size_t size) {
   HASH_ADD(hh_fd, records_by_fd, fd, sizeof(fd), record);
   HASH_ADD(hh_pointer, records_by_pointer, pointer, sizeof(pointer), record);
 
-  // We lie to dlmalloc about where mapped memory actually lives.
+  /* We lie to dlmalloc about where mapped memory actually lives. */
   pointer += sizeof(size_t);
   LOG_DEBUG("%p = fake_mmap(%lu)", pointer, size);
   return pointer;
@@ -113,7 +112,7 @@ void get_malloc_mapinfo(void *addr,
                         int64_t *map_size,
                         ptrdiff_t *offset) {
   struct mmap_record *record;
-  // TODO(rshin): Implement a more efficient search through records_by_fd.
+  /* TODO(rshin): Implement a more efficient search through records_by_fd. */
   for (record = records_by_fd; record != NULL; record = record->hh_fd.next) {
     if (addr >= record->pointer && addr < record->pointer + record->size) {
       *fd = record->fd;

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -36,6 +36,7 @@ struct mmap_record {
   UT_hash_handle hh_pointer;
 };
 
+// TODO(rshin): Don't have two hash tables.
 struct mmap_record *records_by_fd = NULL;
 struct mmap_record *records_by_pointer = NULL;
 
@@ -68,13 +69,14 @@ void *fake_mmap(size_t size) {
   // Add sizeof(size_t) so that the returned pointer is deliberately not
   // page-aligned. This ensures that the segments of memory returned by
   // fake_mmap are never contiguous.
-  int fd = create_buffer(size + sizeof(size_t));
-  void *pointer = mmap(NULL, size + sizeof(size_t), PROT_READ | PROT_WRITE,
+  size += sizeof(size_t);
+
+  int fd = create_buffer(size);
+  void *pointer = mmap(NULL, size, PROT_READ | PROT_WRITE,
                        MAP_SHARED, fd, 0);
   if (pointer == MAP_FAILED) {
     return pointer;
   }
-  pointer += sizeof(size_t);
 
   struct mmap_record *record = malloc(sizeof(struct mmap_record));
   record->fd = fd;
@@ -83,16 +85,19 @@ void *fake_mmap(size_t size) {
   HASH_ADD(hh_fd, records_by_fd, fd, sizeof(fd), record);
   HASH_ADD(hh_pointer, records_by_pointer, pointer, sizeof(pointer), record);
 
+  // We lie to dlmalloc about where mapped memory actually lives.
+  pointer += sizeof(size_t);
   LOG_DEBUG("%p = fake_mmap(%lu)", pointer, size);
   return pointer;
 }
 
 int fake_munmap(void *addr, size_t size) {
   LOG_DEBUG("fake_munmap(%p, %lu)", addr, size);
+  addr -= sizeof(size_t);
+  size += sizeof(size_t);
 
   struct mmap_record *record;
 
-  addr -= sizeof(size_t);
   HASH_FIND(hh_pointer, records_by_pointer, &addr, sizeof(addr), record);
   assert(record != NULL);
   close(record->fd);
@@ -100,7 +105,7 @@ int fake_munmap(void *addr, size_t size) {
   HASH_DELETE(hh_fd, records_by_fd, record);
   HASH_DELETE(hh_pointer, records_by_pointer, record);
 
-  return munmap(addr, size + sizeof(size_t));
+  return munmap(addr, size);
 }
 
 void get_malloc_mapinfo(void *addr,
@@ -113,9 +118,7 @@ void get_malloc_mapinfo(void *addr,
     if (addr >= record->pointer && addr < record->pointer + record->size) {
       *fd = record->fd;
       *map_size = record->size;
-      /* We add sizeof(size_t) here so that the returned pointer is deliberately
-       # not page-aligned. See the documentation for fake_mmap. */
-      *offset = addr - record->pointer + sizeof(size_t);
+      *offset = addr - record->pointer;
       return;
     }
   }

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -113,7 +113,9 @@ void get_malloc_mapinfo(void *addr,
     if (addr >= record->pointer && addr < record->pointer + record->size) {
       *fd = record->fd;
       *map_size = record->size;
-      *offset = addr - record->pointer;
+      /* We add sizeof(size_t) here so that the returned pointer is deliberately
+       # not page-aligned. See the documentation for fake_mmap. */
+      *offset = addr - record->pointer + sizeof(size_t);
       return;
     }
   }

--- a/src/malloc.h
+++ b/src/malloc.h
@@ -6,4 +6,4 @@ void get_malloc_mapinfo(void *addr,
                         int64_t *map_length,
                         ptrdiff_t *offset);
 
-#endif  // MALLOC_H
+#endif /* MALLOC_H */

--- a/src/plasma_client.c
+++ b/src/plasma_client.c
@@ -44,6 +44,8 @@ void plasma_create(int conn,
   assert(reply.metadata_size == metadata_size);
   /* The metadata should come right after the data. */
   assert(reply.metadata_offset == reply.data_offset + data_size);
+
+  // TOOD(rshin): Don't call mmap if this fd has already been mapepd.
   *data = ((uint8_t *) mmap(NULL, reply.map_size, PROT_READ | PROT_WRITE,
                             MAP_SHARED, fd, 0)) +
           reply.data_offset;
@@ -73,6 +75,8 @@ void plasma_get(int conn,
   plasma_reply reply;
   /* The following loop is run at most twice. */
   int fd = recv_fd(conn, (char *) &reply, sizeof(plasma_reply));
+
+  // TOOD(rshin): Don't call mmap if this fd has already been mapepd.
   *data =
       ((uint8_t *) mmap(NULL, reply.map_size, PROT_READ, MAP_SHARED, fd, 0)) +
       reply.data_offset;


### PR DESCRIPTION
There appears to be a misalignment, which can be revealed as follows. In `plasma_client.c` at line 41, add the code

```C
  printf("In Client\n");
  uint8_t* stuff = *data;
  for (int i = 0; i < reply.object_size; ++i) {
    printf("%u ,", stuff[i]);
  }
  printf("\n");
```

In `plasma_store.c` at line 96, add the code

```C
  printf("In Store\n");
  for (int i = 0; i < req->size; ++i) {
    stuff[i] = 77;
  }
  for (int i = 0; i < req->size; ++i) {
    printf("%u ,", stuff[i]);
  }
  printf("\n");
```

Then running the method `test_create` in `TestPlasmaClient` in `test/test.py`, prints the following (after changing `length` in line 35 to `length = 50`):

```
test_create (__main__.TestPlasmaClient) ... [DEBUG] (src/malloc.c:86) 0x1096f4008 = fake_mmap(65536)
In Store
77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,
In Client
67 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,
ok

----------------------------------------------------------------------
Ran 1 test in 0.109s

OK
```

After this PR, it prints the following.

```
test_create (__main__.TestPlasmaClient) ... [DEBUG] (src/malloc.c:86) 0x106d5f008 = fake_mmap(65536)
In Store
77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,
In Client
77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,77 ,
ok

----------------------------------------------------------------------
Ran 1 test in 0.107s

OK
```